### PR TITLE
Pass down query paramaters to brKey.getPublicKeys().

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -31,7 +31,7 @@ bedrock.events.on('bedrock-express.init', function(app) {
 bedrock.events.on('bedrock-express.configure.routes', addRoutes);
 
 function addRoutes(app) {
-  var basePath = bedrock.config['key'].basePath;
+  var basePath = bedrock.config.key.basePath;
   var identityBasePath;
   // FIXME: deprecated old key path
   if('idp' in bedrock.config) {
@@ -118,7 +118,9 @@ function addRoutes(app) {
     brRest.linkedDataHandler({
       get: function(req, res, callback) {
         var actor = req.user ? req.user.identity : undefined;
-        brKey.getPublicKeys(req.query.owner, actor, req.query, function(err, records) {
+        console.log('$$$$$$$$$', req.query);
+        brKey.getPublicKeys(
+          req.query.owner, actor, req.query, function(err, records) {
           if(err) {
             return callback(err);
           }
@@ -272,9 +274,8 @@ bedrock.events.on('bedrock-views.vars.get', addViewVars);
 function addViewVars(req, vars, callback) {
   // FIXME which namespaces?
   vars['key-http'] = {};
-  vars['key-http'].basePath = bedrock.config['key'].basePath;
+  vars['key-http'].basePath = bedrock.config.key.basePath;
   vars['key-http'].baseUri = vars.baseUri + vars['key-http'].basePath;
 
   callback();
 }
-

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,7 +118,7 @@ function addRoutes(app) {
     brRest.linkedDataHandler({
       get: function(req, res, callback) {
         var actor = req.user ? req.user.identity : undefined;
-        brKey.getPublicKeys(req.query.owner, actor, function(err, records) {
+        brKey.getPublicKeys(req.query.owner, actor, req.query, function(err, records) {
           if(err) {
             return callback(err);
           }

--- a/schemas/services.key.js
+++ b/schemas/services.key.js
@@ -23,7 +23,12 @@ var getKeysQuery = {
   type: 'object',
   properties: {
     owner: schemas.identifier({required: true}),
-  }
+    capability: {
+      required: false,
+      enum: ['sign']
+    }
+  },
+  additionalProperties: false
 };
 
 var postKeys = {


### PR DESCRIPTION
Can pass down URL queries to brKey.getPublicKeys now -- right now it only works for the parameter 'capability=sign', to retrieve all keys that are capable of signing data.
